### PR TITLE
Change ANSI syntax

### DIFF
--- a/src/commands/help.luau
+++ b/src/commands/help.luau
@@ -1,23 +1,23 @@
 local ansi = require("@libraries/ansi")
 local help_message = [[
-    usage: {red}rcc{re} [command] [options]
-    {b}Commands:{re}
-      {b}help{re}\t\topen this help menu
-      {st}{b}init{re}{st}\t\tinitialize a project{re} 
-      {st}{b}install{re}{st}\t\tinstall a compiler{re}
-      {st}{b}uninstall{re}{st}\t\tuninstall a compiler{re}
-      {st}{b}update{re}{st}\t\tupdate a compiler{re}
-    {b}Options:{re}
-      {b}-o{re}{st}\t\toutput directory (default: out){re}
-      {b}<none>{re}{st}\t\tinput directory (default: src){re}
-      {b}-d{re}{st}\t\tdebug mode{re}
-    {b}Examples:{re}
-      {st}{b}rcc{re}{st} {b}install{re}{st} roblox-py{re}
-      {st}{b}rcc{re}{st} {b}uninstall{re}{st} roblox-py{re}
-      {st}{b}rcc{re}{st} {b}update{re}{st} roblox-py{re}
-      {st}{b}rcc{re}{st} {b}-o{re}{st} out{re}
-      {st}{b}rcc{re}{st} {b}-o{re}{st} out src{re}
-      {st}{b}rcc{re}{st} {b}include{re}{st} @roblox/roact{re}
+    usage: |red|rcc|re| [command] [options]
+    |b|Commands:|re|
+      |b|help|re|\t\topen this help menu
+      |st||b|init|re||st|\t\tinitialize a project|re| 
+      |st||b|install|re||st|\t\tinstall a compiler|re|
+      |st||b|uninstall|re||st|\t\tuninstall a compiler|re|
+      |st||b|update|re||st|\t\tupdate a compiler|re|
+    |b|Options:|re|
+      |b|-o|re||st|\t\toutput directory (default: out)|re|
+      |b|<none>|re||st|\t\tinput directory (default: src)|re|
+      |b|-d|re||st|\t\tdebug mode|re|
+    |b|Examples:|re|
+      |st||b|rcc|re||st| |b|install|re||st| roblox-py|re|
+      |st||b|rcc|re||st| |b|uninstall|re||st| roblox-py|re|
+      |st||b|rcc|re||st| |b|update|re||st| roblox-py|re|
+      |st||b|rcc|re||st| |b|-o|re||st| out|re|
+      |st||b|rcc|re||st| |b|-o|re||st| out src|re|
+      |st||b|rcc|re||st| |b|include|re||st| @roblox/roact|re|
     ]]
 help_message = ansi.replace(help_message):gsub("\\t", "\t") -- Apparently escape codes don't work in multiline strings
 return function()

--- a/src/libraries/ansi.luau
+++ b/src/libraries/ansi.luau
@@ -2,19 +2,19 @@ local module = {}
 local stdio = require("@lune/stdio")
 
 module.replacements = {
-    ["{re}"] = stdio.style("reset"),
-    ["{b}"] = stdio.style("bold"),
-    ["{dim}"] = stdio.style("dim"),
-    ["{st}"] = "\27[9m",
-    ["{un}"] = "\27[24m",
-    ["{red}"] = stdio.color("red"),
-    ["{green}"] = stdio.color("green"),
-    ["{blue}"] = stdio.color("blue"),
-    ["{yellow}"] = stdio.color("yellow"),
-    ["{purple}"] = stdio.color("purple"),
-    ["{cyan}"] = stdio.color("cyan"),
-    ["{white}"] = stdio.color("white"),
-    ["{black}"] = stdio.color("black"),
+    ["|re|"] = stdio.style("reset"),
+    ["|b|"] = stdio.style("bold"),
+    ["|dim|"] = stdio.style("dim"),
+    ["|st|"] = "\27[9m",
+    ["|un|"] = "\27[24m",
+    ["|red|"] = stdio.color("red"),
+    ["|green|"] = stdio.color("green"),
+    ["|blue|"] = stdio.color("blue"),
+    ["|yellow|"] = stdio.color("yellow"),
+    ["|purple|"] = stdio.color("purple"),
+    ["|cyan|"] = stdio.color("cyan"),
+    ["|white|"] = stdio.color("white"),
+    ["|black|"] = stdio.color("black"),
 }
 
 function module.replace(input:string)


### PR DESCRIPTION
Changed the syntax for ansi.luau from {} to || for compatibility with format strings